### PR TITLE
Capture missing overlap cases

### DIFF
--- a/ner_evaluation/ner_eval.py
+++ b/ner_evaluation/ner_eval.py
@@ -85,6 +85,9 @@ def compute_metrics(true_named_entities, pred_named_entities):
             # check for overlaps with any of the true entities
             for true in true_named_entities:
 
+                pred_range = range(pred.start_offset, pred.end_offset)
+                true_range = range(true.start_offset, true.end_offset)
+
                 # 1. check for an exact match but with a different e_type
                 if true.start_offset == pred.start_offset and pred.end_offset == true.end_offset \
                         and true.e_type != pred.e_type:
@@ -104,7 +107,8 @@ def compute_metrics(true_named_entities, pred_named_entities):
                     break
 
                 # 2. check for an overlap i.e. not exact boundary match, with true entities
-                elif pred.start_offset <= true.end_offset and true.start_offset <= pred.end_offset:
+
+                elif find_overlap(true_range, pred_range):
 
                     true_which_overlapped_with_pred.append(true)
 
@@ -194,3 +198,26 @@ def compute_metrics(true_named_entities, pred_named_entities):
         evaluation[eval_type]['recall'] = recall
 
     return evaluation, evaluation_agg_entities_type
+
+
+def find_overlap(true_range, pred_range):
+    """Find the overlap between two ranges
+
+    Find the overalp between two ranges. Return the overlapping values if
+    present, else return an empty set().
+
+    Examples:
+
+    >>> find_overlap((1, 2), (2, 3))
+    2
+    >>> find_overlap((1, 2), (3, 4))
+    set()
+    """
+
+    true_set = set(true_range)
+    pred_set = set(pred_range)
+
+    overlaps = true_set.intersection(pred_set)
+
+    return overlaps
+

--- a/ner_evaluation/tests/test_ner_evaluation.py
+++ b/ner_evaluation/tests/test_ner_evaluation.py
@@ -3,6 +3,7 @@ import unittest
 from ner_evaluation.ner_eval import Entity
 from ner_evaluation.ner_eval import compute_metrics
 from ner_evaluation.ner_eval import collect_named_entities
+from ner_evaluation.ner_eval import find_overlap
 
 
 class ner_evaluation(unittest.TestCase):
@@ -80,3 +81,64 @@ class ner_evaluation(unittest.TestCase):
                     }
 
         self.assertDictEqual(results, expected)
+
+    def test_find_overlap_no_overlap(self):
+
+        pred_entity = Entity('LOC', 1, 10)
+        true_entity = Entity('LOC', 11, 20)
+
+        pred_range = range(pred_entity.start_offset, pred_entity.end_offset)
+        true_range = range(true_entity.start_offset, true_entity.end_offset)
+
+        pred_set = set(pred_range)
+        true_set = set(true_range)
+
+        intersect = find_overlap(pred_set, true_set)
+
+        self.assertFalse(intersect, set())
+
+
+    def test_find_overlap_total_overlap(self):
+
+        pred_entity = Entity('LOC', 10, 22)
+        true_entity = Entity('LOC', 11, 20)
+
+        pred_range = range(pred_entity.start_offset, pred_entity.end_offset)
+        true_range = range(true_entity.start_offset, true_entity.end_offset)
+
+        pred_set = set(pred_range)
+        true_set = set(true_range)
+
+        intersect = find_overlap(pred_set, true_set)
+
+        self.assertTrue(intersect, set())
+
+    def test_find_overlap_start_overlap(self):
+
+        pred_entity = Entity('LOC', 5, 12)
+        true_entity = Entity('LOC', 11, 20)
+
+        pred_range = range(pred_entity.start_offset, pred_entity.end_offset)
+        true_range = range(true_entity.start_offset, true_entity.end_offset)
+
+        pred_set = set(pred_range)
+        true_set = set(true_range)
+
+        intersect = find_overlap(pred_set, true_set)
+
+        self.assertTrue(intersect, set())
+
+    def test_find_overlap_end_overlap(self):
+
+        pred_entity = Entity('LOC', 15, 25)
+        true_entity = Entity('LOC', 11, 20)
+
+        pred_range = range(pred_entity.start_offset, pred_entity.end_offset)
+        true_range = range(true_entity.start_offset, true_entity.end_offset)
+
+        pred_set = set(pred_range)
+        true_set = set(true_range)
+
+        intersect = find_overlap(pred_set, true_set)
+
+        self.assertTrue(intersect, set())


### PR DESCRIPTION
In the current implementation `compute_metrics()` will only consider an overlap on the [following basis](https://github.com/davidsbatista/NER-Evaluation/blob/576acc0e40bf3a8835d7897e55cfc62f4cb76d6f/ner_evaluation/ner_eval.py#L106):
```
elif pred.start_offset <= true.end_offset and true.start_offset <= pred.end_offset:
```
This captures a 'total overlap' of the `true` entity by the `pred` entity, and a partial overlap of the start of the `true` entity by the `pred` entity, but there is a third case which is not captured, a partial overlap of the end of the `eval` entity by the `pred` entity.
```
Character offset:   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
True:               |   |   |   |LOC|LOC|LOC|LOC|LOC|   |   |
Total overlap:      |   |   |LOC|LOC|LOC|LOC|LOC|LOC|LOC|   |
Start overlap:      |   |   |LOC|LOC|LOC|   |   |   |   |   |
End overlap:        |   |   |   |   |   |   |LOC|LOC|LOC|   |
```
This PR adds logic to `compute_metrics()` to allow it to capture end overlaps as described in the table above.

Essentially I've added a `find_overlap` function which will detect any overlap of two ranges, returning that overlap, or an empty `set()` if none is found. The truth of this output can then be evaluated. Also added tests for four cases: no overlap, total overlap, start overlap, and end overlap.