### PR TITLE
[WIP] Output complete results at the entity level

### DIFF
--- a/example-full-named-entity-evaluation.ipynb
+++ b/example-full-named-entity-evaluation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,8 +114,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.24 s, sys: 115 ms, total: 1.35 s\n",
-      "Wall time: 1.35 s\n"
+      "CPU times: user 744 ms, sys: 44.4 ms, total: 788 ms\n",
+      "Wall time: 791 ms\n"
      ]
     }
    ],
@@ -144,8 +144,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 33.2 s, sys: 188 ms, total: 33.4 s\n",
-      "Wall time: 33.4 s\n"
+      "CPU times: user 26 s, sys: 41.8 ms, total: 26 s\n",
+      "Wall time: 26 s\n"
      ]
     }
    ],
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -247,13 +247,47 @@
        " Entity(e_type='ORG', start_offset=45, end_offset=46)]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "true"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Entity(e_type='MISC', start_offset=12, end_offset=12),\n",
+       " Entity(e_type='LOC', start_offset=15, end_offset=15),\n",
+       " Entity(e_type='PER', start_offset=37, end_offset=39),\n",
+       " Entity(e_type='LOC', start_offset=45, end_offset=46)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 2\n",
+    "true = collect_named_entities(test_sents_labels[index])\n",
+    "pred = collect_named_entities(y_pred[index])"
    ]
   },
   {
@@ -267,44 +301,10 @@
        "[Entity(e_type='MISC', start_offset=12, end_offset=12),\n",
        " Entity(e_type='LOC', start_offset=15, end_offset=15),\n",
        " Entity(e_type='PER', start_offset=37, end_offset=39),\n",
-       " Entity(e_type='LOC', start_offset=45, end_offset=46)]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pred"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "index = 2\n",
-    "true = collect_named_entities(test_sents_labels[index])\n",
-    "pred = collect_named_entities(y_pred[index])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Entity(e_type='MISC', start_offset=12, end_offset=12),\n",
-       " Entity(e_type='LOC', start_offset=15, end_offset=15),\n",
-       " Entity(e_type='PER', start_offset=37, end_offset=39),\n",
        " Entity(e_type='ORG', start_offset=45, end_offset=46)]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -327,7 +327,7 @@
        " Entity(e_type='LOC', start_offset=45, end_offset=46)]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -338,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -348,7 +348,7 @@
        "   'incorrect': 1,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 0,\n",
        "   'possible': 4,\n",
        "   'actual': 4,\n",
        "   'precision': 0.75,\n",
@@ -357,7 +357,7 @@
        "   'incorrect': 1,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 0,\n",
        "   'possible': 4,\n",
        "   'actual': 4,\n",
        "   'precision': 0.75,\n",
@@ -366,7 +366,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 0,\n",
        "   'possible': 4,\n",
        "   'actual': 4,\n",
        "   'precision': 1.0,\n",
@@ -375,7 +375,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 0,\n",
        "   'possible': 4,\n",
        "   'actual': 4,\n",
        "   'precision': 1.0,\n",
@@ -384,85 +384,85 @@
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'partial': {'correct': 0,\n",
+       "    'spurious': 0},\n",
+       "   'partial': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'exact': {'correct': 0,\n",
+       "    'spurious': 0},\n",
+       "   'exact': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
+       "    'spurious': 0}},\n",
        "  'PER': {'strict': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'partial': {'correct': 0,\n",
+       "    'spurious': 0},\n",
+       "   'partial': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'exact': {'correct': 0,\n",
+       "    'spurious': 0},\n",
+       "   'exact': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
+       "    'spurious': 0}},\n",
        "  'LOC': {'strict': {'correct': 1,\n",
-       "    'incorrect': 1,\n",
+       "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 1,\n",
+       "    'incorrect': 0,\n",
+       "    'partial': 0,\n",
+       "    'missed': 0,\n",
+       "    'spurious': 0},\n",
+       "   'partial': {'correct': 1,\n",
+       "    'incorrect': 0,\n",
+       "    'partial': 0,\n",
+       "    'missed': 0,\n",
+       "    'spurious': 0},\n",
+       "   'exact': {'correct': 1,\n",
+       "    'incorrect': 0,\n",
+       "    'partial': 0,\n",
+       "    'missed': 0,\n",
+       "    'spurious': 0}},\n",
+       "  'ORG': {'strict': {'correct': 0,\n",
        "    'incorrect': 1,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'partial': {'correct': 0,\n",
-       "    'incorrect': 0,\n",
-       "    'partial': 0,\n",
-       "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'exact': {'correct': 0,\n",
-       "    'incorrect': 0,\n",
-       "    'partial': 0,\n",
-       "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
-       "  'ORG': {'strict': {'correct': 0,\n",
-       "    'incorrect': 0,\n",
-       "    'partial': 0,\n",
-       "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 0,\n",
+       "    'incorrect': 1,\n",
+       "    'partial': 0,\n",
+       "    'missed': 0,\n",
+       "    'spurious': 0},\n",
+       "   'partial': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'partial': {'correct': 0,\n",
+       "    'spurious': 0},\n",
+       "   'exact': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'exact': {'correct': 0,\n",
-       "    'incorrect': 0,\n",
-       "    'partial': 0,\n",
-       "    'missed': 0,\n",
-       "    'spurius': 0}}})"
+       "    'spurious': 0}}})"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +512,7 @@
        "             'ORG': [Entity(e_type='ORG', start_offset=45, end_offset=46)]})"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -523,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -536,7 +536,7 @@
        "             'PER': [Entity(e_type='PER', start_offset=37, end_offset=39)]})"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -556,7 +556,7 @@
        "[Entity(e_type='LOC', start_offset=15, end_offset=15)]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -567,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -577,7 +577,7 @@
        " Entity(e_type='LOC', start_offset=45, end_offset=46)]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -588,7 +588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -598,7 +598,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 1,\n",
+       "   'spurious': 1,\n",
        "   'possible': 1,\n",
        "   'actual': 2,\n",
        "   'precision': 0.5,\n",
@@ -607,7 +607,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 1,\n",
+       "   'spurious': 1,\n",
        "   'possible': 1,\n",
        "   'actual': 2,\n",
        "   'precision': 0.5,\n",
@@ -616,7 +616,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 1,\n",
+       "   'spurious': 1,\n",
        "   'possible': 1,\n",
        "   'actual': 2,\n",
        "   'precision': 0.5,\n",
@@ -625,7 +625,7 @@
        "   'incorrect': 0,\n",
        "   'partial': 0,\n",
        "   'missed': 0,\n",
-       "   'spurius': 1,\n",
+       "   'spurious': 1,\n",
        "   'possible': 1,\n",
        "   'actual': 2,\n",
        "   'precision': 0.5,\n",
@@ -634,85 +634,85 @@
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'partial': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'exact': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
+       "    'spurious': 0}},\n",
        "  'PER': {'strict': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'partial': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'exact': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
+       "    'spurious': 0}},\n",
        "  'LOC': {'strict': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 1},\n",
+       "    'spurious': 1},\n",
        "   'ent_type': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 1},\n",
-       "   'partial': {'correct': 0,\n",
+       "    'spurious': 1},\n",
+       "   'partial': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
-       "   'exact': {'correct': 0,\n",
+       "    'spurious': 1},\n",
+       "   'exact': {'correct': 1,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}},\n",
+       "    'spurious': 1}},\n",
        "  'ORG': {'strict': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'ent_type': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'partial': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0},\n",
+       "    'spurious': 0},\n",
        "   'exact': {'correct': 0,\n",
        "    'incorrect': 0,\n",
        "    'partial': 0,\n",
        "    'missed': 0,\n",
-       "    'spurius': 0}}})"
+       "    'spurious': 0}}})"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -730,14 +730,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "metrics_results = {'correct': 0, 'incorrect': 0, 'partial': 0,\n",
-    "                   'missed': 0, 'spurius': 0, 'possible': 0, 'actual': 0}\n",
+    "                   'missed': 0, 'spurious': 0, 'possible': 0, 'actual': 0}\n",
     "\n",
     "# overall results\n",
     "results = {'strict': deepcopy(metrics_results),\n",
@@ -768,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -778,33 +778,33 @@
        "  'incorrect': 600,\n",
        "  'partial': 0,\n",
        "  'missed': 176,\n",
-       "  'spurius': 139,\n",
+       "  'spurious': 139,\n",
        "  'possible': 3559,\n",
        "  'actual': 3522},\n",
        " 'ent_type': {'correct': 2860,\n",
        "  'incorrect': 523,\n",
        "  'partial': 0,\n",
        "  'missed': 176,\n",
-       "  'spurius': 139,\n",
+       "  'spurious': 139,\n",
        "  'possible': 3559,\n",
        "  'actual': 3522},\n",
        " 'partial': {'correct': 3278,\n",
        "  'incorrect': 0,\n",
        "  'partial': 105,\n",
        "  'missed': 176,\n",
-       "  'spurius': 139,\n",
+       "  'spurious': 139,\n",
        "  'possible': 3559,\n",
        "  'actual': 3522},\n",
        " 'exact': {'correct': 3278,\n",
        "  'incorrect': 105,\n",
        "  'partial': 0,\n",
        "  'missed': 176,\n",
-       "  'spurius': 139,\n",
+       "  'spurious': 139,\n",
        "  'possible': 3559,\n",
        "  'actual': 3522}}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -815,7 +815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {
     "scrolled": false
    },
@@ -824,120 +824,120 @@
      "data": {
       "text/plain": [
        "{'LOC': {'strict': {'correct': 844,\n",
-       "   'incorrect': 168,\n",
+       "   'incorrect': 191,\n",
        "   'partial': 0,\n",
-       "   'missed': 57,\n",
-       "   'spurius': 38,\n",
+       "   'missed': 49,\n",
+       "   'spurious': 32,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
        "  'ent_type': {'correct': 855,\n",
-       "   'incorrect': 157,\n",
+       "   'incorrect': 180,\n",
        "   'partial': 0,\n",
        "   'missed': 49,\n",
-       "   'spurius': 32,\n",
+       "   'spurious': 32,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'partial': {'correct': 0,\n",
+       "  'partial': {'correct': 1016,\n",
        "   'incorrect': 0,\n",
-       "   'partial': 0,\n",
+       "   'partial': 19,\n",
        "   'missed': 49,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 32,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'exact': {'correct': 0,\n",
-       "   'incorrect': 0,\n",
+       "  'exact': {'correct': 1016,\n",
+       "   'incorrect': 19,\n",
        "   'partial': 0,\n",
        "   'missed': 49,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 32,\n",
        "   'possible': 0,\n",
        "   'actual': 0}},\n",
        " 'PER': {'strict': {'correct': 646,\n",
-       "   'incorrect': 104,\n",
+       "   'incorrect': 72,\n",
        "   'partial': 0,\n",
-       "   'missed': 19,\n",
-       "   'spurius': 15,\n",
+       "   'missed': 17,\n",
+       "   'spurious': 13,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
        "  'ent_type': {'correct': 651,\n",
-       "   'incorrect': 99,\n",
+       "   'incorrect': 67,\n",
        "   'partial': 0,\n",
        "   'missed': 17,\n",
-       "   'spurius': 13,\n",
+       "   'spurious': 13,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'partial': {'correct': 0,\n",
+       "  'partial': {'correct': 711,\n",
        "   'incorrect': 0,\n",
-       "   'partial': 0,\n",
+       "   'partial': 7,\n",
        "   'missed': 17,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 13,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'exact': {'correct': 0,\n",
-       "   'incorrect': 0,\n",
+       "  'exact': {'correct': 711,\n",
+       "   'incorrect': 7,\n",
        "   'partial': 0,\n",
        "   'missed': 17,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 13,\n",
        "   'possible': 0,\n",
        "   'actual': 0}},\n",
        " 'ORG': {'strict': {'correct': 1120,\n",
-       "   'incorrect': 245,\n",
+       "   'incorrect': 221,\n",
        "   'partial': 0,\n",
-       "   'missed': 72,\n",
-       "   'spurius': 78,\n",
+       "   'missed': 59,\n",
+       "   'spurious': 70,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
        "  'ent_type': {'correct': 1154,\n",
-       "   'incorrect': 211,\n",
+       "   'incorrect': 187,\n",
        "   'partial': 0,\n",
        "   'missed': 59,\n",
-       "   'spurius': 70,\n",
+       "   'spurious': 70,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'partial': {'correct': 0,\n",
+       "  'partial': {'correct': 1294,\n",
        "   'incorrect': 0,\n",
-       "   'partial': 0,\n",
+       "   'partial': 47,\n",
        "   'missed': 59,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 70,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'exact': {'correct': 0,\n",
-       "   'incorrect': 0,\n",
+       "  'exact': {'correct': 1294,\n",
+       "   'incorrect': 47,\n",
        "   'partial': 0,\n",
        "   'missed': 59,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 70,\n",
        "   'possible': 0,\n",
        "   'actual': 0}},\n",
        " 'MISC': {'strict': {'correct': 173,\n",
-       "   'incorrect': 55,\n",
+       "   'incorrect': 116,\n",
        "   'partial': 0,\n",
-       "   'missed': 56,\n",
-       "   'spurius': 36,\n",
+       "   'missed': 51,\n",
+       "   'spurious': 24,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
        "  'ent_type': {'correct': 200,\n",
-       "   'incorrect': 28,\n",
+       "   'incorrect': 89,\n",
        "   'partial': 0,\n",
        "   'missed': 51,\n",
-       "   'spurius': 24,\n",
+       "   'spurious': 24,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'partial': {'correct': 0,\n",
+       "  'partial': {'correct': 257,\n",
        "   'incorrect': 0,\n",
-       "   'partial': 0,\n",
+       "   'partial': 32,\n",
        "   'missed': 51,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 24,\n",
        "   'possible': 0,\n",
        "   'actual': 0},\n",
-       "  'exact': {'correct': 0,\n",
-       "   'incorrect': 0,\n",
+       "  'exact': {'correct': 257,\n",
+       "   'incorrect': 32,\n",
        "   'partial': 0,\n",
        "   'missed': 51,\n",
-       "   'spurius': 0,\n",
+       "   'spurious': 24,\n",
        "   'possible': 0,\n",
        "   'actual': 0}}}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -963,7 +963,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/ner_evaluation/ner_eval.py
+++ b/ner_evaluation/ner_eval.py
@@ -50,7 +50,7 @@ def collect_named_entities(tokens):
 
 
 def compute_metrics(true_named_entities, pred_named_entities):
-    eval_metrics = {'correct': 0, 'incorrect': 0, 'partial': 0, 'missed': 0, 'spurius': 0}
+    eval_metrics = {'correct': 0, 'incorrect': 0, 'partial': 0, 'missed': 0, 'spurious': 0}
     target_tags_no_schema = ['MISC', 'PER', 'LOC', 'ORG']
 
     # overall results
@@ -164,25 +164,25 @@ def compute_metrics(true_named_entities, pred_named_entities):
 
                         # Results against the predicted entity
 
-                        # evaluation_agg_entities_type[pred.e_type]['strict']['spurius'] += 1
+                        # evaluation_agg_entities_type[pred.e_type]['strict']['spurious'] += 1
 
                         found_overlap = True
                         break
 
-            # Scenario II: Entities are spurius (i.e., over-generated).
+            # Scenario II: Entities are spurious (i.e., over-generated).
 
             if not found_overlap:
                 # overall results
-                evaluation['strict']['spurius'] += 1
-                evaluation['ent_type']['spurius'] += 1
-                evaluation['partial']['spurius'] += 1
-                evaluation['exact']['spurius'] += 1
+                evaluation['strict']['spurious'] += 1
+                evaluation['ent_type']['spurious'] += 1
+                evaluation['partial']['spurious'] += 1
+                evaluation['exact']['spurious'] += 1
 
                 # aggregated by entity type results
-                evaluation_agg_entities_type[pred.e_type]['strict']['spurius'] += 1
-                evaluation_agg_entities_type[pred.e_type]['ent_type']['spurius'] += 1
-                evaluation_agg_entities_type[pred.e_type]['partial']['spurius'] += 1
-                evaluation_agg_entities_type[pred.e_type]['exact']['spurius'] += 1
+                evaluation_agg_entities_type[pred.e_type]['strict']['spurious'] += 1
+                evaluation_agg_entities_type[pred.e_type]['ent_type']['spurious'] += 1
+                evaluation_agg_entities_type[pred.e_type]['partial']['spurious'] += 1
+                evaluation_agg_entities_type[pred.e_type]['exact']['spurious'] += 1
 
     # Scenario III: Entity was missed entirely.
 
@@ -208,13 +208,13 @@ def compute_metrics(true_named_entities, pred_named_entities):
         incorrect = evaluation[eval_type]['incorrect']
         partial = evaluation[eval_type]['partial']
         missed = evaluation[eval_type]['missed']
-        spurius = evaluation[eval_type]['spurius']
+        spurious = evaluation[eval_type]['spurious']
 
         # possible: nr. annotations in the gold-standard which contribute to the final score
         evaluation[eval_type]['possible'] = correct + incorrect + partial + missed
 
         # actual: number of annotations produced by the NER system
-        evaluation[eval_type]['actual'] = correct + incorrect + partial + spurius
+        evaluation[eval_type]['actual'] = correct + incorrect + partial + spurious
 
         actual = evaluation[eval_type]['actual']
         possible = evaluation[eval_type]['possible']

--- a/ner_evaluation/ner_eval.py
+++ b/ner_evaluation/ner_eval.py
@@ -84,6 +84,8 @@ def compute_metrics(true_named_entities, pred_named_entities):
             # for the agg. by e_type results
             evaluation_agg_entities_type[pred.e_type]['strict']['correct'] += 1
             evaluation_agg_entities_type[pred.e_type]['ent_type']['correct'] += 1
+            evaluation_agg_entities_type[pred.e_type]['exact']['correct'] += 1
+            evaluation_agg_entities_type[pred.e_type]['partial']['correct'] += 1
 
         else:
 
@@ -106,8 +108,10 @@ def compute_metrics(true_named_entities, pred_named_entities):
                     evaluation['exact']['correct'] += 1
 
                     # aggregated by entity type results
-                    evaluation_agg_entities_type[pred.e_type]['strict']['incorrect'] += 1
-                    evaluation_agg_entities_type[pred.e_type]['ent_type']['incorrect'] += 1
+                    evaluation_agg_entities_type[true.e_type]['strict']['incorrect'] += 1
+                    evaluation_agg_entities_type[true.e_type]['ent_type']['incorrect'] += 1
+                    evaluation_agg_entities_type[true.e_type]['partial']['correct'] += 1
+                    evaluation_agg_entities_type[true.e_type]['exact']['correct'] += 1
 
                     true_which_overlapped_with_pred.append(true)
                     found_overlap = True
@@ -132,8 +136,10 @@ def compute_metrics(true_named_entities, pred_named_entities):
                         evaluation['exact']['incorrect'] += 1
 
                         # aggregated by entity type results
-                        evaluation_agg_entities_type[pred.e_type]['strict']['incorrect'] += 1
-                        evaluation_agg_entities_type[pred.e_type]['ent_type']['correct'] += 1
+                        evaluation_agg_entities_type[true.e_type]['strict']['incorrect'] += 1
+                        evaluation_agg_entities_type[true.e_type]['ent_type']['correct'] += 1
+                        evaluation_agg_entities_type[true.e_type]['partial']['partial'] += 1
+                        evaluation_agg_entities_type[true.e_type]['exact']['incorrect'] += 1
 
                         found_overlap = True
                         break
@@ -149,8 +155,16 @@ def compute_metrics(true_named_entities, pred_named_entities):
                         evaluation['exact']['incorrect'] += 1
 
                         # aggregated by entity type results
-                        evaluation_agg_entities_type[true.e_type]['strict']['missed'] += 1
-                        evaluation_agg_entities_type[pred.e_type]['strict']['spurius'] += 1
+                        # Results against the true entity
+
+                        evaluation_agg_entities_type[true.e_type]['strict']['incorrect'] += 1
+                        evaluation_agg_entities_type[true.e_type]['partial']['partial'] += 1
+                        evaluation_agg_entities_type[true.e_type]['ent_type']['incorrect'] += 1
+                        evaluation_agg_entities_type[true.e_type]['exact']['incorrect'] += 1
+
+                        # Results against the predicted entity
+
+                        # evaluation_agg_entities_type[pred.e_type]['strict']['spurius'] += 1
 
                         found_overlap = True
                         break
@@ -167,6 +181,9 @@ def compute_metrics(true_named_entities, pred_named_entities):
                 # aggregated by entity type results
                 evaluation_agg_entities_type[pred.e_type]['strict']['spurius'] += 1
                 evaluation_agg_entities_type[pred.e_type]['ent_type']['spurius'] += 1
+                evaluation_agg_entities_type[pred.e_type]['partial']['spurius'] += 1
+                evaluation_agg_entities_type[pred.e_type]['exact']['spurius'] += 1
+
     # Scenario III: Entity was missed entirely.
 
     for true in true_named_entities:

--- a/ner_evaluation/tests/test_ner_evaluation.py
+++ b/ner_evaluation/tests/test_ner_evaluation.py
@@ -42,7 +42,7 @@ def test_compute_metrics_case_1():
                            'incorrect': 3,
                            'partial': 0,
                            'missed': 1,
-                           'spurius': 1,
+                           'spurious': 1,
                            'possible': 6,
                            'actual': 6,
                            'precision': 0.3333333333333333,
@@ -51,7 +51,7 @@ def test_compute_metrics_case_1():
                              'incorrect': 2,
                              'partial': 0,
                              'missed': 1,
-                             'spurius': 1,
+                             'spurious': 1,
                              'possible': 6,
                              'actual': 6,
                              'precision': 0.5,
@@ -60,7 +60,7 @@ def test_compute_metrics_case_1():
                             'incorrect': 0,
                             'partial': 2,
                             'missed': 1,
-                            'spurius': 1,
+                            'spurious': 1,
                             'possible': 6,
                             'actual': 6,
                             'precision': 0.6666666666666666,
@@ -69,7 +69,7 @@ def test_compute_metrics_case_1():
                           'incorrect': 2,
                           'partial': 0,
                           'missed': 1,
-                          'spurius': 1,
+                          'spurious': 1,
                           'possible': 6,
                           'actual': 6,
                           'precision': 0.5,
@@ -94,28 +94,28 @@ def test_compute_metrics_agg_scenario_3():
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 1,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 1,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 1,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 1,
-                'spurius': 0
+                'spurious': 0
             }
         }
     }
@@ -138,28 +138,28 @@ def test_compute_metrics_agg_scenario_2():
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 1
+                'spurious': 1
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 1
+                'spurious': 1
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 1
+                'spurious': 1
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 1
+                'spurious': 1
             }
         }
     }
@@ -182,28 +182,28 @@ def test_compute_metrics_agg_scenario_5():
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 1,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         }
     }
@@ -225,28 +225,28 @@ def test_compute_metrics_agg_scenario_4():
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         },
         'LOC': {
@@ -255,28 +255,28 @@ def test_compute_metrics_agg_scenario_4():
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         }
     }
@@ -298,28 +298,28 @@ def test_compute_metrics_agg_scenario_1():
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 1,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         }
     }
@@ -341,28 +341,28 @@ def test_compute_metrics_agg_scenario_6():
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 1,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 1,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         },
         'LOC': {
@@ -371,28 +371,28 @@ def test_compute_metrics_agg_scenario_6():
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
                 },
             'ent_type': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'partial': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             },
             'exact': {
                 'correct': 0,
                 'incorrect': 0,
                 'partial': 0,
                 'missed': 0,
-                'spurius': 0
+                'spurious': 0
             }
         }
     }

--- a/ner_evaluation/tests/test_ner_evaluation.py
+++ b/ner_evaluation/tests/test_ner_evaluation.py
@@ -78,6 +78,328 @@ def test_compute_metrics_case_1():
 
     assert results == expected
 
+
+def test_compute_metrics_agg_scenario_3():
+
+    true_named_entities = [Entity('PER', 59, 69)]
+
+    pred_named_entities = []
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 1,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 1,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 1,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 1,
+                'spurius': 0
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+
+
+def test_compute_metrics_agg_scenario_2():
+
+    true_named_entities = []
+
+    pred_named_entities = [Entity('PER', 59, 69)]
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 1
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 1
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 1
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 1
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+
+
+def test_compute_metrics_agg_scenario_5():
+
+    true_named_entities = [Entity('PER', 59, 69)]
+
+    pred_named_entities = [Entity('PER', 57, 69)]
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 1,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+
+def test_compute_metrics_agg_scenario_4():
+
+    true_named_entities = [Entity('PER', 59, 69)]
+
+    pred_named_entities = [Entity('LOC', 59, 69)]
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        },
+        'LOC': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+
+def test_compute_metrics_agg_scenario_1():
+
+    true_named_entities = [Entity('PER', 59, 69)]
+
+    pred_named_entities = [Entity('PER', 59, 69)]
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 1,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+
+def test_compute_metrics_agg_scenario_6():
+
+    true_named_entities = [Entity('PER', 59, 69)]
+
+    pred_named_entities = [Entity('LOC', 54, 69)]
+
+    results, results_agg = compute_metrics(true_named_entities, pred_named_entities)
+
+    expected_agg = {
+        'PER': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 1,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 1,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        },
+        'LOC': {
+            'strict': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+                },
+            'ent_type': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'partial': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            },
+            'exact': {
+                'correct': 0,
+                'incorrect': 0,
+                'partial': 0,
+                'missed': 0,
+                'spurius': 0
+            }
+        }
+    }
+
+    assert results_agg["PER"] == expected_agg["PER"]
+    assert results_agg["LOC"] == expected_agg["LOC"]
+
 def test_find_overlap_no_overlap():
 
     pred_entity = Entity('LOC', 1, 10)


### PR DESCRIPTION
* Added tests for the 6 scenarios outlined in the [blog](http://www.davidsbatista.net/blog/2018/05/09/Named_Entity_Evaluation/).
* Changed in-line comments to reflect the numbering of the six scenarios.
* Add logic to calculate results for each entity type.
* Correct spelling mistake of spurious in source code and ipynb.

@davidsbatista please have a look at the test cases for the six scenarios. The thing I'm not sure about is how to deal with scenarios IV and VI where the entity type of the `true` and `pred` does not match. In both cases I have only scored against the true entity, not the predicted one, but the predicted entity could also be scored as spurious. Not sure what to do here, would it be double counting to count it in both ways? 