### PR TITLE
Pin scikit-learn version to 0.23.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sklearn
+scikit-learn==0.23.2
 nltk
 sklearn_crfsuite
 pytest


### PR DESCRIPTION
Pull request refering to #23 

Pin the version of scikit-learn to 0.23.2 to keep the repo working seemlessly.